### PR TITLE
Keep the same order of arguments sent to the callback in _each when using $ or _

### DIFF
--- a/backend.ckan.js
+++ b/backend.ckan.js
@@ -31,8 +31,18 @@ this.recline.Backend.Ckan = this.recline.Backend.Ckan || {};
   // use either jQuery or Underscore Deferred depending on what is available
   var underscoreOrJquery = this.jQuery || this._;
   var _map = underscoreOrJquery.map;
-  var _each = underscoreOrJquery.each;
   var _deferred = underscoreOrJquery.Deferred;
+  var _each = function _each(list, iterator) {
+      // jQuery calls the iterator with (index, value), while underscore uses
+      // (value, index). We use always (value, index).
+      if (this.jQuery) {
+          this.jQuery.each(list, function (index, value) {
+              iterator(value, index);
+          });
+      } else {
+          this._.each(list, iterator);
+      }
+  }
 
   // Default CKAN API endpoint used for requests (you can change this but it will affect every request!)
   //


### PR DESCRIPTION
jQuery.each() calls the passed iterator giving (index, value), while _.each()
uses (value, index).

This fix makes both use (value, index).

This problem was introduced by me at 2364ad02e0cea232fca6770f25aa4c497c7f7740.

@rgrp I'm wondering how useful is it to support Underscore, as to use it, you'll also need https://github.com/wookiehangover/underscore.Deferred (right?).

If we move towards something like ckan.js, it will be good to avoid depending on anything at all.
