### PR TITLE
Use lodash not underscore node

### DIFF
--- a/ckan.js
+++ b/ckan.js
@@ -3,7 +3,7 @@ var CKAN = {};
 var isNodeModule = (typeof module !== 'undefined' && module != null && typeof require !== 'undefined');
 
 if (isNodeModule) {
-  var _ = require('underscore')
+  var _ = require('lodash')
     , request = require('request')
     ;
   module.exports = CKAN;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   , "license": "MIT"
   , "dependencies": {
       "request": ""
-    , "underscore": ""
+    , "lodash": ""
   }
   , "devDependencies": {
   }


### PR DESCRIPTION
[Lo-Dash](http://lodash.com/) is a more performant drop-in replacement for Underscore.js.