### PR TITLE
Update to work with latest request under node

### DIFF
--- a/ckan.js
+++ b/ckan.js
@@ -141,7 +141,7 @@ if (isNodeModule) {
       json: options.data
     };
     // we could just call request but that's a PITA to mock plus request.get = request (if you look at the source code)
-    request.get(conf, function(err, res, body) {
+    request(conf, function(err, res, body) {
       if (!err && res && !(res.statusCode === 200 || res.statusCode === 302)) {
         err = 'CKANJS API Error. HTTP code ' + res.statusCode + '. Message: ' + JSON.stringify(body, null, 2);
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ckan"
-  , "version": "0.2.2"
+  , "version": "0.2.3"
   , "author": "Open Knowledge Foundation <labs@okfn.org>"
   , "main": "ckan.js"
   , "repository": {
@@ -9,8 +9,8 @@
   }
   , "license": "MIT"
   , "dependencies": {
-      "request": ""
-    , "underscore": ""
+      "request": "~= 2.51.0"
+    , "underscore": "~= 1.7.0"
   }
   , "devDependencies": {
   }


### PR DESCRIPTION
Commenting on:
// we could just call request but that's a PITA to mock plus request.get = request (if you look at the source code)

This is not anymore true, method=GET is forced when using get(): https://github.com/request/request/blob/master/index.js#L60