### PR TITLE
Added option for requestType

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ var client = new CKAN.Client('http://my-ckan-site.com');
 
 // You can also provide an API key (for operations that require one)
 var client = new CKAN.Client('http://my-ckan-site.com', 'my-api-key');
+
+// If your portal disallows POST requests (note: limited support in browser module)
+client.requestType = 'GET';
 ```
 
 You can now use any part of the [action API][]:
@@ -235,4 +238,3 @@ This module also provides a Recline compatible backend available as:
 
 The backend supports `fetch` and `query` but does not provide write support at
 the present time.
-

--- a/ckan.js
+++ b/ckan.js
@@ -5,6 +5,7 @@ var isNodeModule = (typeof module !== 'undefined' && module != null && typeof re
 if (isNodeModule) {
   var _ = require('underscore')
     , request = require('request')
+    , queryString = require('query-string')
     ;
   module.exports = CKAN;
 }
@@ -26,7 +27,9 @@ if (isNodeModule) {
       type: this.requestType
     };
     if (options.type == 'GET') {
-      options.url += '?' + queryString.stringify(data);
+      options.url += '?' + isNodeModule ?
+        queryString.stringify(data, {arrayFormat: 'none'}) :
+        'q=' + data.q + '&sort=' + data.sort; // i.e. other clients must use q & sort
     }
     return this._ajax(options, cb);
   };
@@ -39,7 +42,7 @@ if (isNodeModule) {
     }
     var meth = isNodeModule ? _nodeRequest : _browserRequest;
     return meth(options, cb);
-  }
+  };
 
   // Like search but supports ReclineJS style query structure
   //

--- a/ckan.js
+++ b/ckan.js
@@ -10,9 +10,10 @@ if (isNodeModule) {
 }
 
 (function(my) {
-  my.Client = function(endpoint, apiKey) { 
+  my.Client = function(endpoint, apiKey) {
     this.endpoint = _getEndpoint(endpoint);
     this.apiKey = apiKey;
+    this.requestType = 'POST';
   };
 
   my.Client.prototype.action = function(name, data, cb) {
@@ -22,7 +23,7 @@ if (isNodeModule) {
     var options = {
       url: this.endpoint + '/3/action/' + name,
       data: data,
-      type: 'POST'
+      type: this.requestType
     };
     return this._ajax(options, cb);
   };
@@ -99,7 +100,7 @@ if (isNodeModule) {
     'bool': 'boolean',
   };
 
-  // 
+  //
   my.jsonTableSchema2CkanTypes = {
     'string': 'text',
     'number': 'float',
@@ -143,7 +144,7 @@ if (isNodeModule) {
     // we could just call request but that's a PITA to mock plus request.get = request (if you look at the source code)
     request(conf, function(err, res, body) {
       if (!err && res && !(res.statusCode === 200 || res.statusCode === 302)) {
-        err = 'CKANJS API Error. HTTP code ' + res.statusCode + '. Message: ' + JSON.stringify(body, null, 2);
+        err = 'CKANJS API Error. HTTP code ' + res.statusCode + '. Options: ' + JSON.stringify(options, null, 2) + ' Message: ' + JSON.stringify(body, null, 2);
       }
       cb(err, body);
     });
@@ -160,7 +161,7 @@ if (isNodeModule) {
         code: obj.status,
         message: obj.responseText
       }
-      cb(err); 
+      cb(err);
     }
     if (options.headers) {
       options.beforeSend = function(req) {
@@ -222,7 +223,7 @@ if (isNodeModule) {
 // This provides connection to the CKAN DataStore (v2)
 //
 // General notes
-// 
+//
 // We need 2 things to make most requests:
 //
 // 1. CKAN API endpoint
@@ -230,13 +231,13 @@ if (isNodeModule) {
 //
 // There are 2 ways to specify this information.
 //
-// EITHER (checked in order): 
+// EITHER (checked in order):
 //
 // * Every dataset must have an id equal to its resource id on the CKAN instance
 // * The dataset has an endpoint attribute pointing to the CKAN API endpoint
 //
 // OR:
-// 
+//
 // Set the url attribute of the dataset to point to the Resource on the CKAN instance. The endpoint and id will then be automatically computed.
 var recline = recline || {};
 recline.Backend = recline.Backend || {};
@@ -286,4 +287,3 @@ recline.Backend.Ckan = recline.Backend.Ckan || {};
     return dfd.promise();
   };
 }(recline.Backend.Ckan));
-

--- a/ckan.js
+++ b/ckan.js
@@ -25,6 +25,9 @@ if (isNodeModule) {
       data: data,
       type: this.requestType
     };
+    if (options.type == 'GET') {
+      options.url += '?' + queryString.stringify(data);
+    }
     return this._ajax(options, cb);
   };
 

--- a/ckan.js
+++ b/ckan.js
@@ -27,9 +27,10 @@ if (isNodeModule) {
       type: this.requestType
     };
     if (options.type == 'GET') {
-      options.url += '?' + isNodeModule ?
+      var qs = isNodeModule ?
         queryString.stringify(data, {arrayFormat: 'none'}) :
         'q=' + data.q + '&sort=' + data.sort; // i.e. other clients must use q & sort
+      options.url += '?' + qs;
     }
     return this._ajax(options, cb);
   };

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-    "name": "ckan"
-  , "version": "0.2.3"
-  , "author": "Open Knowledge Foundation <labs@okfn.org>"
-  , "main": "ckan.js"
-  , "repository": {
+  "name": "ckan",
+  "version": "0.2.3",
+  "author": "Open Knowledge Foundation <labs@okfn.org>",
+  "main": "ckan.js",
+  "repository": {
     "type": "git",
     "url": "https://github.com/okfn/ckan.js"
-  }
-  , "license": "MIT"
-  , "dependencies": {
-      "request": "~= 2.51.0"
-    , "underscore": "~= 1.7.0"
-  }
-  , "devDependencies": {
-  }
+  },
+  "license": "MIT",
+  "dependencies": {
+    "query-string": "^4.3.1",
+    "request": "~= 2.51.0",
+    "underscore": "~= 1.7.0"
+  },
+  "devDependencies": {}
 }


### PR DESCRIPTION
Some portals do not allow / support POST requests. We could alternatively try to autodetect this, but for performance reasons I think having the option would be good. NB: still needs to be documented.