### PR TITLE
Created functions to get files changed in a dataset after a specific date, and also to upload various files into a CKAN package easily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-node_modules/
+node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CDNJS](https://img.shields.io/cdnjs/v/ckan.svg)](https://cdnjs.com/libraries/ckan)
+
 A Javascript client library for [CKAN][] designed for both the browser and
 NodeJS.
 
@@ -58,6 +60,9 @@ var client = new CKAN.Client('http://my-ckan-site.com');
 
 // You can also provide an API key (for operations that require one)
 var client = new CKAN.Client('http://my-ckan-site.com', 'my-api-key');
+
+// If your portal disallows POST requests (note: limited support in browser module)
+client.requestType = 'GET';
 ```
 
 You can now use any part of the [action API][]:
@@ -233,4 +238,3 @@ This module also provides a Recline compatible backend available as:
 
 The backend supports `fetch` and `query` but does not provide write support at
 the present time.
-

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ DataStore API][ckan-api].
 It also provides a [Recline compatible backend][recline-backend].
 
 [CKAN]: http://ckan.org/
-[ckan-api]: http://docs.ckan.org/en/latest/datastore-api.html
+[ckan-api]: http://docs.ckan.org/en/latest/maintaining/datastore.html#the-datastore-api
 [recline-backend]: http://reclinejs.com/docs/backends.html
 [Recline]: http://reclinejs.com/
 
@@ -151,7 +151,7 @@ var csv = require('csv');
 csv()
   .from('path/to/csv-file.csv', {columns: true})
   .to.array(function(data, count) {
-    client.create({
+    client.action('datastore_create', {
         resource_id: resourceId,
         records: data
       },
@@ -171,7 +171,7 @@ details of options:
 [ds-search]: http://docs.ckan.org/en/latest/maintaining/datastore.html#ckanext.datastore.logic.action.datastore_search
 
 ```
-client.action('dataset_search', {
+client.action('datastore_search', {
     resource_id: '...',
     q: '...'
   },
@@ -185,7 +185,7 @@ client.action('dataset_search', {
 Or using SQL support:
 
 ```
-client.action('dataset_search_sql', {
+client.action('datastore_search_sql', {
     sql: '...'
   },
   function(err, out) {
@@ -213,7 +213,7 @@ client.datastoreQuery(queryObj, function(err, out) {
 And for SQL
 
 ```
-client.datastoreQuery(sql, function(err, out) {
+client.datastoreSqlQuery(sql, function(err, out) {
   // out will follow recline structure, viz
   {
     total: ..

--- a/README.md
+++ b/README.md
@@ -15,15 +15,17 @@ It also provides a [Recline compatible backend][recline-backend].
 
 ### Browser
 
-Just add the `ckan.js` to your page.
+The [JQuery library](https://jquery.com/) is required for use in the browser.  After that, just add the `ckan.js` script to your page.
 
 ```
+<script src="jquery-2.1.4.min.js"></script>
 <script src="ckan.js"></script>
 ```
 
 You can also use our hosted one:
 
 ```
+<script src="http://code.jquery.com/jquery-2.1.4.min.js"></script>
 <script src="http://okfnlabs.org/ckan.js/ckan.js"></script>
 ```
 

--- a/ckan.js
+++ b/ckan.js
@@ -117,7 +117,7 @@ if (isNodeModule) {
     var data = {
       resource_id: '_table_metadata'
     };
-    return this._client.action('datastore_search', data, cb);
+    return this.action('datastore_search', data, cb);
   };
 
   // Utilities

--- a/ckan.js
+++ b/ckan.js
@@ -141,7 +141,7 @@ if (isNodeModule) {
       json: options.data
     };
     // we could just call request but that's a PITA to mock plus request.get = request (if you look at the source code)
-    request.get(conf, function(err, res, body) {
+    request(conf, function(err, res, body) {
       if (!err && res && !(res.statusCode === 200 || res.statusCode === 302)) {
         err = 'CKANJS API Error. HTTP code ' + res.statusCode + '. Message: ' + JSON.stringify(body, null, 2);
       }

--- a/ckan.js
+++ b/ckan.js
@@ -3,215 +3,492 @@ var CKAN = {};
 var isNodeModule = (typeof module !== 'undefined' && module != null && typeof require !== 'undefined');
 
 if (isNodeModule) {
-  var _ = require('underscore')
-    , request = require('request')
-    ;
-  module.exports = CKAN;
+    var _ = require('underscore')
+        , request = require('request')
+        ;
+    module.exports = CKAN;
 }
 
 (function(my) {
-  my.Client = function(endpoint, apiKey) { 
-    this.endpoint = _getEndpoint(endpoint);
-    this.apiKey = apiKey;
-  };
-
-  my.Client.prototype.action = function(name, data, cb) {
-    if (name.indexOf('dataset_' === 0)) {
-      name = name.replace('dataset_', 'package_');
-    }
-    var options = {
-      url: this.endpoint + '/3/action/' + name,
-      data: data,
-      type: 'POST'
+    my.Client = function(endpoint, apiKey) {
+        this.endpoint = _getEndpoint(endpoint);
+        this.apiKey = apiKey;
     };
-    return this._ajax(options, cb);
-  };
 
-  // make an AJAX request
-  my.Client.prototype._ajax = function(options, cb) {
-    options.headers = options.headers || {};
-    if (this.apiKey) {
-      options.headers['X-CKAN-API-KEY'] = this.apiKey;
+    /**
+     * Creating a client via username and password authentication
+     * credit https://github.com/jrmerz/node-ckan
+     * @param endpoint
+     * @param username
+     * @param password
+     * @param callback
+     * @constructor
+     */
+
+    my.Client = function(endpoint, username, password, callback)
+    {
+        post({
+            url : endpoint + "/login_generic",
+            expected : 302,
+            data : {
+                login    : username,
+                password : password,
+                remember : 63072000
+            },
+            callback : function(error, response) {
+                if( error ) return callback(error);
+                scrapeToken();
+            }
+        });
+
+        // HACK, credit https://github.com/jrmerz/node-ckan
+        // TODO: can we get this token from the cookie?
+        function scrapeToken()  {
+            get({
+                url : server + "/user/"+username,
+                callback : function(error, body) {
+                    if( error ) return callback(error);
+                    jsdom.env(body,
+                        ["http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"],
+                        function(errors, window) {
+                            var apikey = window.$("dd.value code");
+                            if( apikey.length > 0 ) {
+                                self.apiKey = apikey.html();
+                                callback();
+                            } else {
+                                callback({error:true,message:"login failed"});
+                            }
+                        }
+                    );
+                }
+            })
+        }
     }
-    var meth = isNodeModule ? _nodeRequest : _browserRequest;
-    return meth(options, cb);
-  }
 
-  // Like search but supports ReclineJS style query structure
-  //
-  // Primarily for use by Recline backend below
-  my.Client.prototype.datastoreQuery = function(queryObj, cb) {
-    var actualQuery = my._normalizeQuery(queryObj);
-    this.action('datastore_search', actualQuery, function(err, results) {
-      if (err) {
-        cb(err);
-        return;
-      }
+    /**
+     * Uploads a file into a CKAN Dataset
+     * @param absolutePathToFileToBeUploaded
+     * @param packageId ID of the dataset into which the file needs to be uploaded
+     * @param description Description of the file
+     * @param fileName Full name of the file (i.e. photo.png)
+     * @param extension File extension of the uploaded file, without the dot (i.e png, not .png)
+     * @param format Format of the uploaded file, Typically extension in UPPERCASE LETTERS
+     * @param callback
+     * @param {string} [resourceUrl] Final URL of the uploaded resource (typically http://ckan-server.com/dataset/ >>>>>packageID<<<<<< /resource/ >>>>>FileName<<<<<
+     * @param {string} [mimetype] of the uploaded file
+     * @param {boolean} [overwriteIfExists] Will overwrite a file if it exists in the @packageId
+     */
 
-      // map ckan types to our usual types ...
-      var fields = _.map(results.result.fields, function(field) {
-        field.type = field.type in my.ckan2JsonTableSchemaTypes ? my.ckan2JsonTableSchemaTypes[field.type] : field.type;
-        return field;
-      });
-      var out = {
-        total: results.result.total,
-        fields: fields,
-        hits: results.result.records
-      };
-      cb(null, out);
-    });
-  };
+    my.client.upload_file_into_package = function(
+        absolutePathToFileToBeUploaded,
+        packageId,
+        description,
+        fileName,
+        extension,
+        format,
+        callback,
+        resourceUrl,
+        mimetype,
+        overwriteIfExists
+    )
+    {
+        var self = this;
+        if(resourceUrl == null)
+        {
+            resourceUrl = self + "/dataset/" + packageId + "/resource/" + filename;
+        }
 
-  my.Client.prototype.datastoreSqlQuery = function(sql, cb) {
-    this.action('datastore_search_sql', {sql: sql}, function(err, results) {
-      if (err) {
-        var parsed = JSON.parse(err.message);
-        var errOut = {
-          original: err,
-          code: err.code,
-          message: parsed.error.info.orig[0]
+        if(mimetype == null)
+        {
+            var mime = require('mime-types')
+            mimetype = mime.lookup(extension);
+        }
+
+        if(overwriteIfExists === null)
+        {
+            overwriteIfExists = false;
+        }
+
+        var file = {
+            url : resourceUrl,
+            package_id : packageId,
+            description: description || '< no description available >',
+            name: fileName,
+            mimetype: mimetype,
+            extension : fileExtension
         };
-        cb(errOut);
-        return;
-      }
 
-      // map ckan types to our usual types ...
-      var fields = _.map(results.result.fields, function(field) {
-        field.type = field.type in my.ckan2JsonTableSchemaTypes ? my.ckan2JsonTableSchemaTypes[field.type] : field.type;
-        return field;
-      });
-      var out = {
-        total: results.result.length,
-        fields: fields,
-        hits: results.result.records
-      };
-      cb(null, out);
-    });
-  };
+        var checkIfPackageExists = function(callback)
+        {
+            var queryString = "res_url: \""+resourceUrl+"\"";
+            my.Client.prototype.action("package_search",
+                {
+                    fq : queryString
+                },
+                function(err, response)
+                {
+                    if(!err && response.result != null)
+                    {
+                        callback(err, response.result.success);
+                    }
+                    else
+                    {
+                        callback(1, response.result);
+                    }
+                });
+        };
 
-  my.ckan2JsonTableSchemaTypes = {
-    'text': 'string',
-    'int': 'integer',
-    'int4': 'integer',
-    'int8': 'integer',
-    'float8': 'float',
-    'timestamp': 'datetime',
-    'bool': 'boolean',
-  };
+        var createResourceInPackage = function(callback)
+        {
+            my.Client.prototype.action("resource_create",
+                file,
+                function (err, response)
+                {
+                    if (response.success)
+                    {
+                        var rest = require('restler');
+                        var fs = require('fs');
 
-  // 
-  my.jsonTableSchema2CkanTypes = {
-    'string': 'text',
-    'number': 'float',
-    'integer': 'int',
-    'datetime': 'timestamp',
-    'boolean': 'bool',
-    'binary': 'bytea',
-    'object': 'json',
-    'array': 'text[]',
-    'any': 'text'
-  };
+                        fs.stat(file.absolute_path, function(err, stats){
+                            if(!err)
+                            {
+                                rest.post(self.endpoint +"/api/action/resource_create", {
+                                    multipart: true,
+                                    headers : {
+                                        Authorization: self.apiKey
+                                    },
+                                    data: {
+                                        id: response.result.id,
+                                        upload: rest.file(absolutePathToFileToBeUploaded, null, stats.size, null, file.mimetype),
+                                        format : format,
+                                        name : file.name,
+                                        description : file.description,
+                                        url : response.result.url,
+                                        package_id : packageId
+                                    }
+                                }).on('complete', function(response, body) {
+                                    if(response != null && response.success)
+                                    {
+                                        callback(null, body);
+                                    }
+                                    else
+                                    {
+                                        callback(1, response.result)
+                                    }
+                                }).on('error', function(response, body) {
+                                    if(response != null && response.success)
+                                    {
+                                        callback(null, body);
+                                    }
+                                    else
+                                    {
+                                        callback(1, "Unknown error occurred uploading file to CKAN");
+                                    }
+                                });
+                            }
+                            else
+                            {
+                                callback(1, "File " + absolutePathToFileToBeUploaded + " does not exist.");
+                            }
+                        });
+                    }
+                    else
+                    {
+                        callback(err, response);
+                    }
+                }
+            );
+        };
 
-  // list all the resources with an entry in the DataStore
-  my.Client.prototype.datastoreResources = function(cb) {
-    var data = {
-      resource_id: '_table_metadata'
-    };
-    return this.action('datastore_search', data, cb);
-  };
+        var updateResourceInPackage = function(callback)
+        {
+            my.Client.prototype.action("resource_update",
+                file,
+                function (err, response)
+                {
+                    if (response.success)
+                    {
+                        var rest = require('restler');
+                        var fs = require('fs');
 
-  // Utilities
-  // =========
+                        fs.stat(file.absolute_path, function(err, stats){
+                            if(!err)
+                            {
+                                rest.post(self.endpoint +"/api/action/resource_update", {
+                                    multipart: true,
+                                    headers : {
+                                        Authorization: self.apiKey
+                                    },
+                                    data: {
+                                        id: response.result.id,
+                                        upload: rest.file(absolutePathToFileToBeUploaded, null, stats.size, null, file.mimetype),
+                                        format : format,
+                                        name : file.name,
+                                        description : file.description,
+                                        url : response.result.url,
+                                        package_id : packageId
+                                    }
+                                }).on('complete', function(response, body) {
+                                    if(response != null && response.success)
+                                    {
+                                        callback(null, body);
+                                    }
+                                    else
+                                    {
+                                        callback(1, response.result)
+                                    }
+                                }).on('error', function(response, body) {
+                                    if(response != null && response.success)
+                                    {
+                                        callback(null, body);
+                                    }
+                                    else
+                                    {
+                                        callback(1, "Unknown error occurred uploading file to CKAN");
+                                    }
+                                });
+                            }
+                            else
+                            {
+                                callback(1, "File " + absolutePathToFileToBeUploaded + " does not exist.");
+                            }
+                        });
+                    }
+                    else
+                    {
+                        callback(err, response);
+                    }
+                }
+            );
+        };
 
-  var _getEndpoint = function(endpoint) {
-    endpoint = endpoint || '/';
-    // strip trailing /
-    endpoint = endpoint.replace(/\/$/, '');
-    if (!endpoint.match(/\/api$/)) {
-      endpoint += '/api';
+        var async = require('async');
+
+        async.waterfall([
+            function(cb)
+            {
+                checkIfPackageExists(cb);
+            },
+            function(exists, cb)
+            {
+                if(exists)
+                {
+                    if(overwriteIfExists)
+                    {
+                        updateResourceInPackage(cb);
+                    }
+                    else
+                    {
+                        cb(1, "Resource already exists in the package and the overwrite flag was not specified.");
+                    }
+                }
+                else
+                {
+                    createResourceInPackage(cb);
+                }
+            }
+        ], function(err, results){
+            callback(err, results);
+        });
     }
-    return endpoint;
-  };
 
-  var _nodeRequest = function(options, cb) {
-    var conf = {
-      url: options.url,
-      headers: options.headers || {},
-      method: options.type || 'GET',
-      json: options.data
-    };
-    // we could just call request but that's a PITA to mock plus request.get = request (if you look at the source code)
-    request(conf, function(err, res, body) {
-      if (!err && res && !(res.statusCode === 200 || res.statusCode === 302)) {
-        err = 'CKANJS API Error. HTTP code ' + res.statusCode + '. Message: ' + JSON.stringify(body, null, 2);
-      }
-      cb(err, body);
-    });
-  };
-
-  var _browserRequest = function(options, cb) {
-    var self = this;
-    options.data = encodeURIComponent(JSON.stringify(options.data));
-    options.success = function(data) {
-      cb(null, data);
-    }
-    options.error = function(obj, obj2, obj3) {
-      var err = {
-        code: obj.status,
-        message: obj.responseText
-      }
-      cb(err); 
-    }
-    if (options.headers) {
-      options.beforeSend = function(req) {
-        for (key in options.headers) {
-          req.setRequestHeader(key, options.headers[key]);
+    my.Client.prototype.action = function(name, data, cb) {
+        if (name.indexOf('dataset_' === 0)) {
+            name = name.replace('dataset_', 'package_');
         }
-      };
-    }
-    return jQuery.ajax(options);
-  };
-
-  // only put in the module namespace so we can access for tests!
-  my._normalizeQuery = function(queryObj) {
-    var actualQuery = {
-      resource_id: queryObj.resource_id,
-      q: queryObj.q,
-      filters: {},
-      limit: queryObj.size || 10,
-      offset: queryObj.from || 0
+        var options = {
+            url: this.endpoint + '/3/action/' + name,
+            data: data,
+            type: 'POST'
+        };
+        return this._ajax(options, cb);
     };
 
-    if (queryObj.sort && queryObj.sort.length > 0) {
-      var _tmp = _.map(queryObj.sort, function(sortObj) {
-        return sortObj.field + ' ' + (sortObj.order || '');
-      });
-      actualQuery.sort = _tmp.join(',');
-    }
-
-    if (queryObj.filters && queryObj.filters.length > 0) {
-      _.each(queryObj.filters, function(filter) {
-        if (filter.type === "term") {
-          actualQuery.filters[filter.field] = filter.term;
+    // make an AJAX request
+    my.Client.prototype._ajax = function(options, cb) {
+        options.headers = options.headers || {};
+        if (this.apiKey) {
+            options.headers['X-CKAN-API-KEY'] = this.apiKey;
         }
-      });
+        var meth = isNodeModule ? _nodeRequest : _browserRequest;
+        return meth(options, cb);
     }
-    return actualQuery;
-  };
 
-  // Parse a normal CKAN resource URL and return API endpoint etc
-  //
-  // Normal URL is something like http://demo.ckan.org/dataset/some-dataset/resource/eb23e809-ccbb-4ad1-820a-19586fc4bebd
-  //
-  // :return: { resource_id: ..., endpoint: ... }
-  my.parseCkanResourceUrl = function(url) {
-    parts = url.split('/');
-    var len = parts.length;
-    return {
-      resource_id: parts[len-1],
-      endpoint: parts.slice(0,[len-4]).join('/') + '/api'
+    // Like search but supports ReclineJS style query structure
+    //
+    // Primarily for use by Recline backend below
+    my.Client.prototype.datastoreQuery = function(queryObj, cb) {
+        var actualQuery = my._normalizeQuery(queryObj);
+        this.action('datastore_search', actualQuery, function(err, results) {
+            if (err) {
+                cb(err);
+                return;
+            }
+
+            // map ckan types to our usual types ...
+            var fields = _.map(results.result.fields, function(field) {
+                field.type = field.type in my.ckan2JsonTableSchemaTypes ? my.ckan2JsonTableSchemaTypes[field.type] : field.type;
+                return field;
+            });
+            var out = {
+                total: results.result.total,
+                fields: fields,
+                hits: results.result.records
+            };
+            cb(null, out);
+        });
     };
-  };
+
+    my.Client.prototype.datastoreSqlQuery = function(sql, cb) {
+        this.action('datastore_search_sql', {sql: sql}, function(err, results) {
+            if (err) {
+                var parsed = JSON.parse(err.message);
+                var errOut = {
+                    original: err,
+                    code: err.code,
+                    message: parsed.error.info.orig[0]
+                };
+                cb(errOut);
+                return;
+            }
+
+            // map ckan types to our usual types ...
+            var fields = _.map(results.result.fields, function(field) {
+                field.type = field.type in my.ckan2JsonTableSchemaTypes ? my.ckan2JsonTableSchemaTypes[field.type] : field.type;
+                return field;
+            });
+            var out = {
+                total: results.result.length,
+                fields: fields,
+                hits: results.result.records
+            };
+            cb(null, out);
+        });
+    };
+
+    my.ckan2JsonTableSchemaTypes = {
+        'text': 'string',
+        'int': 'integer',
+        'int4': 'integer',
+        'int8': 'integer',
+        'float8': 'float',
+        'timestamp': 'datetime',
+        'bool': 'boolean',
+    };
+
+    //
+    my.jsonTableSchema2CkanTypes = {
+        'string': 'text',
+        'number': 'float',
+        'integer': 'int',
+        'datetime': 'timestamp',
+        'boolean': 'bool',
+        'binary': 'bytea',
+        'object': 'json',
+        'array': 'text[]',
+        'any': 'text'
+    };
+
+    // list all the resources with an entry in the DataStore
+    my.Client.prototype.datastoreResources = function(cb) {
+        var data = {
+            resource_id: '_table_metadata'
+        };
+        return this.action('datastore_search', data, cb);
+    };
+
+    // Utilities
+    // =========
+
+    var _getEndpoint = function(endpoint) {
+        endpoint = endpoint || '/';
+        // strip trailing /
+        endpoint = endpoint.replace(/\/$/, '');
+        if (!endpoint.match(/\/api$/)) {
+            endpoint += '/api';
+        }
+        return endpoint;
+    };
+
+    var _nodeRequest = function(options, cb) {
+        var conf = {
+            url: options.url,
+            headers: options.headers || {},
+            method: options.type || 'GET',
+            json: options.data
+        };
+        // we could just call request but that's a PITA to mock plus request.get = request (if you look at the source code)
+        request(conf, function(err, res, body) {
+            if (!err && res && !(res.statusCode === 200 || res.statusCode === 302)) {
+                err = 'CKANJS API Error. HTTP code ' + res.statusCode + '. Message: ' + JSON.stringify(body, null, 2);
+            }
+            cb(err, body);
+        });
+    };
+
+    var _browserRequest = function(options, cb) {
+        var self = this;
+        options.data = encodeURIComponent(JSON.stringify(options.data));
+        options.success = function(data) {
+            cb(null, data);
+        }
+        options.error = function(obj, obj2, obj3) {
+            var err = {
+                code: obj.status,
+                message: obj.responseText
+            }
+            cb(err);
+        }
+        if (options.headers) {
+            options.beforeSend = function(req) {
+                for (key in options.headers) {
+                    req.setRequestHeader(key, options.headers[key]);
+                }
+            };
+        }
+        return jQuery.ajax(options);
+    };
+
+    // only put in the module namespace so we can access for tests!
+    my._normalizeQuery = function(queryObj) {
+        var actualQuery = {
+            resource_id: queryObj.resource_id,
+            q: queryObj.q,
+            filters: {},
+            limit: queryObj.size || 10,
+            offset: queryObj.from || 0
+        };
+
+        if (queryObj.sort && queryObj.sort.length > 0) {
+            var _tmp = _.map(queryObj.sort, function(sortObj) {
+                return sortObj.field + ' ' + (sortObj.order || '');
+            });
+            actualQuery.sort = _tmp.join(',');
+        }
+
+        if (queryObj.filters && queryObj.filters.length > 0) {
+            _.each(queryObj.filters, function(filter) {
+                if (filter.type === "term") {
+                    actualQuery.filters[filter.field] = filter.term;
+                }
+            });
+        }
+        return actualQuery;
+    };
+
+    // Parse a normal CKAN resource URL and return API endpoint etc
+    //
+    // Normal URL is something like http://demo.ckan.org/dataset/some-dataset/resource/eb23e809-ccbb-4ad1-820a-19586fc4bebd
+    //
+    // :return: { resource_id: ..., endpoint: ... }
+    my.parseCkanResourceUrl = function(url) {
+        parts = url.split('/');
+        var len = parts.length;
+        return {
+            resource_id: parts[len-1],
+            endpoint: parts.slice(0,[len-4]).join('/') + '/api'
+        };
+    };
 }(CKAN));
 
 
@@ -222,7 +499,7 @@ if (isNodeModule) {
 // This provides connection to the CKAN DataStore (v2)
 //
 // General notes
-// 
+//
 // We need 2 things to make most requests:
 //
 // 1. CKAN API endpoint
@@ -230,60 +507,60 @@ if (isNodeModule) {
 //
 // There are 2 ways to specify this information.
 //
-// EITHER (checked in order): 
+// EITHER (checked in order):
 //
 // * Every dataset must have an id equal to its resource id on the CKAN instance
 // * The dataset has an endpoint attribute pointing to the CKAN API endpoint
 //
 // OR:
-// 
+//
 // Set the url attribute of the dataset to point to the Resource on the CKAN instance. The endpoint and id will then be automatically computed.
 var recline = recline || {};
 recline.Backend = recline.Backend || {};
 recline.Backend.Ckan = recline.Backend.Ckan || {};
 (function(my) {
-  my.__type__ = 'ckan';
+    my.__type__ = 'ckan';
 
-  // private - use either jQuery or Underscore Deferred depending on what is available
-  var Deferred = _.isUndefined(this.jQuery) ? _.Deferred : jQuery.Deferred;
+    // private - use either jQuery or Underscore Deferred depending on what is available
+    var Deferred = _.isUndefined(this.jQuery) ? _.Deferred : jQuery.Deferred;
 
-  // ### fetch
-  my.fetch = function(dataset) {
-    var dfd = new Deferred()
-    my.query({}, dataset)
-      .done(function(data) {
-        dfd.resolve({
-          fields: data.fields,
-          records: data.hits
+    // ### fetch
+    my.fetch = function(dataset) {
+        var dfd = new Deferred()
+        my.query({}, dataset)
+            .done(function(data) {
+                dfd.resolve({
+                    fields: data.fields,
+                    records: data.hits
+                });
+            })
+            .fail(function(err) {
+                dfd.reject(err);
+            })
+        ;
+        return dfd.promise();
+    };
+
+    my.query = function(queryObj, dataset) {
+        var dfd = new Deferred()
+            , wrapper
+            ;
+        if (dataset.endpoint) {
+            wrapper = new CKAN.Client(dataset.endpoint);
+        } else {
+            var out = CKAN.parseCkanResourceUrl(dataset.url);
+            dataset.id = out.resource_id;
+            wrapper = new CKAN.Client(out.endpoint);
+        }
+        queryObj.resource_id = dataset.id;
+        wrapper.datastoreQuery(queryObj, function(err, out) {
+            if (err) {
+                dfd.reject(err);
+            } else {
+                dfd.resolve(out);
+            }
         });
-      })
-      .fail(function(err) {
-        dfd.reject(err);
-      })
-      ;
-    return dfd.promise();
-  };
-
-  my.query = function(queryObj, dataset) {
-    var dfd = new Deferred()
-      , wrapper
-      ;
-    if (dataset.endpoint) {
-      wrapper = new CKAN.Client(dataset.endpoint);
-    } else {
-      var out = CKAN.parseCkanResourceUrl(dataset.url);
-      dataset.id = out.resource_id;
-      wrapper = new CKAN.Client(out.endpoint);
-    }
-    queryObj.resource_id = dataset.id;
-    wrapper.datastoreQuery(queryObj, function(err, out) {
-      if (err) {
-        dfd.reject(err);
-      } else {
-        dfd.resolve(out);
-      }
-    });
-    return dfd.promise();
-  };
+        return dfd.promise();
+    };
 }(recline.Backend.Ckan));
 

--- a/ckan.js
+++ b/ckan.js
@@ -105,7 +105,8 @@ if (isNodeModule) {
     }
 
     my.Client.prototype.action = function(name, data, cb) {
-        if (name.indexOf('dataset_' === 0)) {
+        if(name !== "dataset_purge" && name.indexOf('dataset_') === 0)
+        {
             name = name.replace('dataset_', 'package_');
         }
         var options = {
@@ -178,6 +179,46 @@ if (isNodeModule) {
         });
     };
 
+
+    /**
+     * Get a list of resources that where changed after a certain date in a dataset
+     * @param lastSyncDate the date of the last time the changes were synced
+     * @param packageId Id of the ckan dataset (package) to be checked
+     * @param callback Response callback
+     */
+
+    my.Client.prototype.getChangesInDatasetAfterDate = function(
+        lastSyncDate,
+        packageId,
+        callback)
+    {
+        var self = this;
+
+        self.action("package_show",
+            {
+                id: packageId
+            },
+            function (err, result) {
+                if (result.success) {
+                    folderResourcesInCkan = result.result.resources;
+                    let changedResources = [];
+                    async.map(result.result.resources, function(resource, callback){
+                        if(resource.last_modified > lastSyncDate)
+                        {
+                            changedResources.push(resource);
+                        }
+                        callback(null, resource);
+                    }, function(err, results){
+                        result.result.changedResources = changedResources;
+                        callback(err, result);
+                    });
+                }
+                else {
+                    callback(err, result);
+                }
+            });
+    }
+
     /**
      * Uploads a series of files into the CKAN repository
      * @param resources Array of resources to upload
@@ -218,7 +259,7 @@ if (isNodeModule) {
             );
         }
 
-        async.eachSeries(resources, uploadFile, function(err, results){
+        async.mapSeries(resources, uploadFile, function(err, results){
             callback(err, results);
         });
     }
@@ -376,7 +417,7 @@ if (isNodeModule) {
                                             }
                                             else
                                             {
-                                                callback(1, response.result)
+                                                callback(1, response.body)
                                             }
                                         }
                                         else

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,876 @@
+{
+  "name": "ckan",
+  "version": "0.2.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abab": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
+    },
+    "acorn": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+      "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc="
+    },
+    "acorn-globals": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+      "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
+      "requires": {
+        "acorn": "2.7.0"
+      }
+    },
+    "ajv": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "json-schema-traverse": "0.3.1",
+        "json-stable-stringify": "1.0.1"
+      }
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "async": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "bl": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+      "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+      "requires": {
+        "readable-stream": "1.0.34"
+      }
+    },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "requires": {
+        "hoek": "4.2.0"
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "requires": {
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        }
+      }
+    },
+    "cssom": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
+    },
+    "cssstyle": {
+      "version": "0.2.37",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+      "requires": {
+        "cssom": "0.3.2"
+      }
+    },
+    "ctype": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "escodegen": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
+      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "requires": {
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.5.7"
+      }
+    },
+    "esprima": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.2.3",
+        "har-schema": "2.0.0"
+      }
+    },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.0.2"
+      }
+    },
+    "hoek": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg="
+    },
+    "inherits": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "jsdom": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-7.2.2.tgz",
+      "integrity": "sha1-QLQCdwwr2iNGkJa+6Rq2deOx/G4=",
+      "requires": {
+        "abab": "1.0.4",
+        "acorn": "2.7.0",
+        "acorn-globals": "1.0.9",
+        "cssom": "0.3.2",
+        "cssstyle": "0.2.37",
+        "escodegen": "1.9.0",
+        "nwmatcher": "1.4.2",
+        "parse5": "1.5.1",
+        "request": "2.83.0",
+        "sax": "1.2.4",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.3.3",
+        "webidl-conversions": "2.0.1",
+        "whatwg-url-compat": "0.6.5",
+        "xml-name-validator": "2.0.1"
+      },
+      "dependencies": {
+        "request": {
+          "version": "2.83.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.1",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          }
+        }
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "mime-db": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+    },
+    "mime-types": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
+    "nwmatcher": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.2.tgz",
+      "integrity": "sha512-QMkCGQFYp5p+zwU3INntLmz1HMfSx9dMVJMYKmE1yuSf/22Wjo6VPFa405mCLUuQn9lbQvH2DZN9lt10ZNvtAg=="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "parse5": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
+    },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "requires": {
+        "process": "0.11.10",
+        "util": "0.10.3"
+      }
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
+    },
+    "request": {
+      "version": "2.51.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+      "integrity": "sha1-NdALvswBLlX5B7G9ng29V3v+8m4=",
+      "requires": {
+        "aws-sign2": "0.5.0",
+        "bl": "0.9.5",
+        "caseless": "0.8.0",
+        "combined-stream": "0.0.7",
+        "forever-agent": "0.5.2",
+        "form-data": "0.2.0",
+        "hawk": "1.1.1",
+        "http-signature": "0.10.1",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "1.0.2",
+        "node-uuid": "1.4.8",
+        "oauth-sign": "0.5.0",
+        "qs": "2.3.3",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.4.3"
+      },
+      "dependencies": {
+        "asn1": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+          "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
+        },
+        "assert-plus": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
+        },
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+        },
+        "aws-sign2": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM="
+        },
+        "boom": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+          "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
+          "requires": {
+            "hoek": "0.9.1"
+          }
+        },
+        "caseless": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
+          "integrity": "sha1-W8oogdQUN/VLJAfr40iIx7mtT30="
+        },
+        "combined-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+          "requires": {
+            "delayed-stream": "0.0.5"
+          }
+        },
+        "cryptiles": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+          "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
+          "requires": {
+            "boom": "0.4.2"
+          }
+        },
+        "delayed-stream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
+        },
+        "forever-agent": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+          "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA="
+        },
+        "form-data": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+          "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
+          "requires": {
+            "async": "0.9.2",
+            "combined-stream": "0.0.7",
+            "mime-types": "2.0.14"
+          },
+          "dependencies": {
+            "mime-types": {
+              "version": "2.0.14",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+              "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+              "requires": {
+                "mime-db": "1.12.0"
+              }
+            }
+          }
+        },
+        "hawk": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+          "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
+          "requires": {
+            "boom": "0.4.2",
+            "cryptiles": "0.2.2",
+            "hoek": "0.9.1",
+            "sntp": "0.2.4"
+          }
+        },
+        "hoek": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+          "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
+        },
+        "http-signature": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+          "requires": {
+            "asn1": "0.1.11",
+            "assert-plus": "0.1.5",
+            "ctype": "0.5.3"
+          }
+        },
+        "mime-db": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+          "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
+        },
+        "mime-types": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+          "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4="
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+        },
+        "oauth-sign": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
+          "integrity": "sha1-12f1FpMlYg6rLgh+8MRy53PbZGE="
+        },
+        "qs": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+          "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ="
+        },
+        "sntp": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+          "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
+          "requires": {
+            "hoek": "0.9.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+        }
+      }
+    },
+    "restler": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/restler/-/restler-3.4.0.tgz",
+      "integrity": "sha1-dB7As9FrlJ/uooE9DDxoUp6IjZs=",
+      "requires": {
+        "iconv-lite": "0.2.11",
+        "qs": "1.2.0",
+        "xml2js": "0.4.0",
+        "yaml": "0.2.3"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.0.tgz",
+          "integrity": "sha1-7Qeb4oaCFH5v2aNMwrDB4OxkU+4="
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "slugify": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.2.1.tgz",
+      "integrity": "sha512-WgTaDQNSyEKXlNKHO8L0DJJtE3gLK83pTx9OM941PnDVhPpZ93FHIbF2D9b0W6d5DsMwBkd56cRFKgxXkPN2KA=="
+    },
+    "sntp": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
+      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+      "requires": {
+        "hoek": "4.2.0"
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "optional": true
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "symbol-tree": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+    },
+    "tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "requires": {
+        "inherits": "2.0.1"
+      }
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-2.0.1.tgz",
+      "integrity": "sha1-O/glj30xjHRDw28uFpQCoaZwNQY="
+    },
+    "whatwg-url-compat": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz",
+      "integrity": "sha1-AImBEa9om7CXVBzVpFymyHmERb8=",
+      "requires": {
+        "tr46": "0.0.3"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
+    "xml-name-validator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
+    },
+    "xml2js": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.0.tgz",
+      "integrity": "sha1-Ek/EEUtBKcgQgA7LKshs8lRiy5o=",
+      "requires": {
+        "sax": "0.5.8",
+        "xmlbuilder": "9.0.4"
+      },
+      "dependencies": {
+        "sax": {
+          "version": "0.5.8",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+          "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
+        }
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
+      "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8="
+    },
+    "yaml": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-0.2.3.tgz",
+      "integrity": "sha1-tUUOkudu82td0k42YAkeuu7z5cc="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "query-string": "^4.3.1",
     "request": "~= 2.51.0",
     "underscore": "~= 1.7.0",
     "restler": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   , "dependencies": {
       "request": "~= 2.51.0"
     , "underscore": "~= 1.7.0"
+    , "restler": "^3.4.0"
+    , "mime-types": "^2.1.13"
+    , "async": "^2.1.4"
   }
   , "devDependencies": {
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ckan"
-  , "version": "0.2.2"
+  , "version": "0.2.3"
   , "author": "Open Knowledge Foundation <labs@okfn.org>"
   , "main": "ckan.js"
   , "repository": {
@@ -9,8 +9,8 @@
   }
   , "license": "MIT"
   , "dependencies": {
-      "request": ""
-    , "underscore": ""
+      "request": "~= 2.51.0"
+    , "underscore": "~= 1.7.0"
   }
   , "devDependencies": {
   }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     , "mime-types": "^2.1.13"
     , "async": "^2.1.4"
     , "jsdom": "^7.0.0"
+	, "querystring" : "*"
   }
   , "devDependencies": {
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     , "restler": "^3.4.0"
     , "mime-types": "^2.1.13"
     , "async": "^2.1.4"
+    , "jsdom": "^7.0.0"
   }
   , "devDependencies": {
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     , "jsdom": "^7.0.0"
     , "path" : "*"
 	  , "querystring" : "*"
+	  , "slugify" : "*"
   }
   , "devDependencies": {
   }

--- a/package.json
+++ b/package.json
@@ -1,24 +1,23 @@
 {
-    "name": "ckan"
-  , "version": "0.2.3"
-  , "author": "Open Knowledge Foundation <labs@okfn.org>"
-  , "main": "ckan.js"
-  , "repository": {
+  "name": "ckan",
+  "version": "0.2.3",
+  "author": "Open Knowledge Foundation <labs@okfn.org>",
+  "main": "ckan.js",
+  "repository": {
     "type": "git",
     "url": "https://github.com/okfn/ckan.js"
-  }
-  , "license": "MIT"
-  , "dependencies": {
-      "request": "~= 2.51.0"
-    , "underscore": "~= 1.7.0"
-    , "restler": "^3.4.0"
-    , "mime-types": "^2.1.13"
-    , "async": "^2.1.4"
-    , "jsdom": "^7.0.0"
-    , "path" : "*"
-	  , "querystring" : "*"
-	  , "slugify" : "*"
-  }
-  , "devDependencies": {
-  }
+  },
+  "license": "MIT",
+  "dependencies": {
+    "request": "~= 2.51.0",
+    "underscore": "~= 1.7.0",
+    "restler": "^3.4.0",
+    "mime-types": "^2.1.13",
+    "async": "^2.1.4",
+    "jsdom": "^7.0.0",
+    "path": "*",
+    "querystring": "*",
+    "slugify": "*"
+  },
+  "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     , "mime-types": "^2.1.13"
     , "async": "^2.1.4"
     , "jsdom": "^7.0.0"
-	, "querystring" : "*"
+    , "path" : "*"
+	  , "querystring" : "*"
   }
   , "devDependencies": {
   }


### PR DESCRIPTION
This code is based on this pull request https://github.com/okfn/ckan.js/pull/24, although the scraping of the api token was removed as requested by @rufuspollock 

1- Is there any reason why every action that starts with "dataset_" is replaced with "package_" ? 

I wrote some automated tests for our platform [Dendro](https://github.com/feup-infolab/dendro) that test package exporting from Dendro to CKAN instances. The tests run very frequently and are always creating new packages, so after each test I would like to purge them by calling the action ["dataset_purge"](http://docs.ckan.org/en/ckan-2.7.0/api/#ckan.logic.action.delete.dataset_purge). To do this, I had to change some code in ckan.js, as I noticed that you are replacing every action (my.Client.prototype.action) that starts with "dataset_" with "package_". 

Before (maybe a bug, because the parenthesis in the if are not closed at the right place, as the comparison is always false):
````
    if (name.indexOf('dataset_' === 0)) {
      name = name.replace('dataset_', 'package_');
    }
````

After:
````
  my.Client.prototype.action = function(name, data, cb) {
    if (name !== "dataset_purge" && name.indexOf('dataset_') === 0) {
      name = name.replace('dataset_', 'package_');
    }
````

2- We added a function getChangesInDatasetAfterDate which calculates the resources changed in CKAN after a given date, something very simple but likely boilerplate code in others using ckan.js. It was useful to us at Dendro to warn Dendro users that changes were or not made on the package on the CKAN side so we thought it would be a useful contribution for this pull request. It may be useful in similar scenarios, where: 1. one makes a deposit in CKAN through an external client, 2. updates the original data in CKAN and then tries to "refresh" the dataset deposited in CKAN via the said client. We figured that users would like to be warned before potentially destroying something that was meanwhile done on the CKAN side.

3- Would you be interested in a function that given an array of objects ( with properties filepath, file metadata and fileID) would update the full package in Ckan ? This is useful in scenarios where a client that exports datasets to CKAN needs to keep track of those deposited datasets and allow for subsequent updates (much like mentioned in the previous point). Such a function allows the client to easily refresh the files and metadata in CKAN if any files or metadata is updated in the client. We have already implemented this for Dendro but we believe it can be useful to other CKAN users and platforms where data is dynamic.